### PR TITLE
Fit Time width for mobile display

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,7 +43,7 @@
                 <div class="mdl-card mdl-cell mdl-cell--9-col-desktop mdl-cell--6-col-tablet mdl-cell--4-col-phone mdl-color--grey-800" id="eta_area">
                     <div class="mdl-card__supporting-text">
                         <label for="eta" id="eta_label" class="mdl-typography--headline mdl-color-text--grey-600">STまで</label>
-                        <p id="eta" class="mdl-typography--display-4 mdl-color-text--grey-200"></p>
+                        <p id="eta" class="mdl-typography--display-4 mdl-color-text--grey-200 stt-mobile-time"></p>
                         <p id="offset" class="mdl-typography--headline mdl-color-text--grey-600"></p>
                     </div>
                 </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -498,6 +498,10 @@ a {
     transition: opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
+  .stt-mobile-time {
+    font-size: 84px;
+  }
+
   /* WebViews in iOS 9 break the "~" operator, and WebViews in OS X 10.10 break
      consecutive "+" operators in some cases. Therefore, we need to use both
      here to cover all the bases. */


### PR DESCRIPTION
いつも利用させてもらっていますmm

Mobile で利用した際に Time 部分が少し切れていたのでこの pull-request でちゃんと window 内に入るようにしました。

CSS 全然苦手なので、 class 名等問題があるようでしたら修正いたします。

---

Change Time width when you look this app in moble devise.

Is the CSS class name OK? If you don't prefer it, I'll fix it :smiley: 

---

## Before

![stt-before](https://user-images.githubusercontent.com/6119086/39282247-923dde08-4943-11e8-9aea-481a9803c005.png)


## After

![stt-changed](https://user-images.githubusercontent.com/6119086/39282251-9665f862-4943-11e8-9194-c8f6d9118445.png)
