### PR TITLE
Better Time font-width for mobile

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -499,7 +499,7 @@ a {
   }
 
   .stt-mobile-time {
-    font-size: 84px;
+    font-size: 22vw;
   }
 
   /* WebViews in iOS 9 break the "~" operator, and WebViews in OS X 10.10 break


### PR DESCRIPTION
何度も失礼しますmm

iPhoneSE で時間部分が切れる、という問題に対処した内容になります。

調べたら viewport percentage というものがあるというのがわかり、そちらで指定するように致しました :raising_hand_woman: px を直接指定するよりもまともな解決方法だと思います。

お時間ある時に確認していただければと思います :smile:

## iPhone6S Plus

![stt-vw-6plus](https://user-images.githubusercontent.com/6119086/39311972-4932ca96-49a9-11e8-898b-650fbf08de8c.png)

## iPhone6

![stt-vw-6](https://user-images.githubusercontent.com/6119086/39311987-5145c8dc-49a9-11e8-916a-a24034c2848d.png)

## iPhoneSE

![stt-vw-se](https://user-images.githubusercontent.com/6119086/39311991-56eb154e-49a9-11e8-8a57-4aaa37ea9716.png)
